### PR TITLE
Build site and publish to github pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container:
+      image: althack/ros:noetic-dev 
+      volumes:
+        - my_docker_volume:/volume_mount
+      options: --cpus 1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          git submodule update --init --recursive
+          sudo apt update
+          sudo apt install libenchant-2-dev -y python3-empy zip
+          python3 -m pip install --upgrade pip
+          apt install python3.8-venv -y
+          python3 -m venv docs-env
+          ls
+          ls docs-env
+          ls docs-env/bin
+          . docs-env/bin/activate
+          pip install -r requirements.txt
+          cd _modules/mirte-python
+          pip install .
+          pip install empy==3.3.4
+          cd ../catkin_ws/src/mirte-ros-packages
+          ls | grep -xv "mirte_msgs" | xargs rm -rf
+          cd ../../
+          catkin_make # or catkin build
+          . devel/setup.sh
+          cd ../../
+          make html
+          zip -r _build/html.zip _build/html
+      - name: install nodejs for archive script
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+          sudo apt-get install -y nodejs        
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: |
+            _build/html.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,8 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: althack/ros:noetic-dev 
-      volumes:
-        - my_docker_volume:/volume_mount
-      options: --cpus 1
+      image: althack/ros:noetic-dev
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,9 @@ jobs:
           . devel/setup.sh
           cd ../../
           make html
-          zip -r _build/html.zip _build/html
+          cd _build/html
+          zip -r ../../site.zip .
+          cd ../../
       - name: install nodejs for archive script
         run: |
           curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
@@ -44,4 +46,4 @@ jobs:
         with:
           name: dist
           path: |
-            _build/html.zip
+            _build/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Build site
 
 on: [push]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,18 @@ jobs:
           name: act_dist
           path: |
             site.zip
+      - name: Upload as a github-pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with: 
+          path: _build/html
+
   deploy:
     # Add a dependency to the build job
     needs: build
-
+    # on:
+    #   push:
+    #     branches:
+    #       - main
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages
@@ -73,5 +81,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          artifact_name: dist
+        # with:
+        #   artifact_name: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,7 @@ jobs:
   deploy:
     # Add a dependency to the build job
     needs: build
-    # on:
-    #   push:
-    #     branches:
-    #       - main
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: althack/ros:noetic-dev
-      options: --user 1001
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
+          git config --global --add safe.directory /__w/mirte-documentation/mirte-documentation
           git submodule update --init --recursive
           sudo apt update
           sudo apt install libenchant-2-dev -y python3-empy zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build site
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,36 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
           sudo apt-get install -y nodejs        
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |
             _build/html
+      - name: Archive production artifacts for act
+        uses: actions/upload-artifact@v4
+        with:
+          name: act_dist
+          path: |
+            site.zip
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: dist

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linkcheck:

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -3,7 +3,7 @@ name: Python package
 on: [push]
 
 jobs:
-  build:
+  linkcheck:
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This will build the site and upload it to gh-pages ( https://arendjan.github.io/mirte-documentation/ , only on main pushes)
Also has #4 included.